### PR TITLE
Fix code scanning alert no. 111: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const rateLimit = require('express-rate-limit');
 
 const { MongoClient, ServerApiVersion } = require('mongodb');
 const uri = "mongodb+srv://publicGithubAuth:3HQaWMwhAu7MVi4n@devweb.or5phdi.mongodb.net/?retryWrites=true&w=majority";
@@ -348,6 +349,11 @@ app.get('/movimientos', async (req, res) => {
   });
 });
 
+const retirarLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 app.post('/recargar', async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
@@ -564,7 +570,7 @@ app.post('/transferir', async (req, res) => {
   });
 });
 
-app.post('/retirar', async (req, res) => {
+app.post('/retirar', retirarLimiter, async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^5.6.0",
     "mongoose": "^7.1.0",
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "express-rate-limit": "^7.4.1"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/111](https://github.com/ElProConLag/dw_2023/security/code-scanning/111)

To fix the problem, we will use the `express-rate-limit` package to add rate limiting to the Express application. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the `/retirar` endpoint within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `index.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum number of requests per minute).
4. Apply the rate limiter to the `/retirar` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
