### PR TITLE
Fix code scanning alert no. 44: Database query built from user-controlled sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ app.post('/usuario', async (req, res) => {
     });
     return;
   }
-  const emailExists = await collection.findOne({ email: email });
+  const emailExists = await collection.findOne({ email: { $eq: email } });
   console.log('Email exists:', emailExists);
   if (emailExists) {
     console.log('Email already exists');


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/44](https://github.com/ElProConLag/dw_2023/security/code-scanning/44)

To fix the problem, we need to ensure that the user input is sanitized before being used in the MongoDB query. The best way to do this is by using the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
