### PR TITLE
Fix code scanning alert no. 109: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,7 +354,12 @@ const retirarLimiter = rateLimit({
   max: 100, // limit each IP to 100 requests per windowMs
 });
 
-app.post('/recargar', async (req, res) => {
+const recargarLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.post('/recargar', recargarLimiter, async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/109](https://github.com/ElProConLag/dw_2023/security/code-scanning/109)

To fix the problem, we need to apply a rate limiter to the `/recargar` route. This can be done by using the `express-rate-limit` middleware, which is already imported and used in the code. We will create a new rate limiter specifically for the `/recargar` route and apply it to that route.

1. Define a new rate limiter for the `/recargar` route.
2. Apply this rate limiter to the `/recargar` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
