### PR TITLE
Fix code scanning alert no. 110: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@ const express = require('express');
 const jwt = require('jsonwebtoken');
 const rateLimit = require('express-rate-limit');
 
+const transferirLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 const { MongoClient, ServerApiVersion } = require('mongodb');
 const uri = "mongodb+srv://publicGithubAuth:3HQaWMwhAu7MVi4n@devweb.or5phdi.mongodb.net/?retryWrites=true&w=majority";
 
@@ -451,7 +456,7 @@ app.post('/recargar', recargarLimiter, async (req, res) => {
   });
 });
 
-app.post('/transferir', async (req, res) => {
+app.post('/transferir', transferirLimiter, async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/110](https://github.com/ElProConLag/dw_2023/security/code-scanning/110)

To fix the problem, we need to apply rate limiting to the `/transferir` route. This can be achieved by using the `express-rate-limit` middleware. We will define a rate limiter and apply it to the route handler. The rate limiter will restrict the number of requests that can be made to the `/transferir` endpoint within a specified time window.

1. Define a rate limiter with appropriate settings (e.g., maximum of 100 requests per 15 minutes).
2. Apply the rate limiter to the `/transferir` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
