### PR TITLE
Fix code scanning alert no. 67: Database query built from user-controlled sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,7 +540,7 @@ app.post('/transferir', transferirLimiter, async (req, res) => {
       });
       return;
     }
-    const userToExists = await collection.findOne({ email: email });
+    const userToExists = await collection.findOne({ email: { $eq: email } });
     console.log('User to exists:', userToExists);
     if (!userToExists) {
       console.log('User does not exist');
@@ -570,7 +570,7 @@ app.post('/transferir', transferirLimiter, async (req, res) => {
     };
     console.log('New amount to:', newAmountTo);
     const resultTo = await collection.updateOne(
-      { email: email },
+      { email: { $eq: email } },
       { $set: { amount: newAmountTo }, $push: { movements: newMovementTo } }
     );
     console.log('Result to:', resultTo);


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/67](https://github.com/ElProConLag/dw_2023/security/code-scanning/67)

To fix the problem, we need to ensure that the user input is sanitized or validated before being used in the MongoDB query. The best way to fix this is to use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This approach is straightforward and does not change the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
