### PR TITLE
Fix code scanning alert no. 107: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ app.get('/salir', (req, res) => {
   });
 });
 
-app.post('/usuario', async (req, res) => {
+app.post('/usuario', transferirLimiter, async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
@@ -303,7 +303,7 @@ app.get('/usuario', async (req, res) => {
   });
 });
 
-app.get('/movimientos', async (req, res) => {
+app.get('/movimientos', transferirLimiter, async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/107](https://github.com/ElProConLag/dw_2023/security/code-scanning/107)

To fix the problem, we need to apply the existing rate limiter (`transferirLimiter`) to the `/usuario` and `/movimientos` routes. This will ensure that these routes are protected against DoS attacks by limiting the number of requests that can be made to them within a specified time window.

1. Identify the routes that need rate limiting (`/usuario` and `/movimientos`).
2. Apply the `transferirLimiter` middleware to these routes.
3. Ensure that the rate limiter is applied before the route handlers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
