### PR TITLE
Fix code scanning alert no. 43: Database query built from user-controlled sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,14 @@ app.post('/usuario', transferirLimiter, async (req, res) => {
     return;
   }
   const collection = client.db("apibank").collection("usuarios");
-  const userExists = await collection.findOne({ name: name });
+  if (typeof name !== "string") {
+    console.log('Invalid name');
+    res.status(400).json({
+      message: 'Nombre no válido'
+    });
+    return;
+  }
+  const userExists = await collection.findOne({ name: { $eq: name } });
   console.log('User exists:', userExists);
   if (userExists) {
     console.log('User already exists');


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/43](https://github.com/ElProConLag/dw_2023/security/code-scanning/43)

To fix the problem, we need to ensure that the user-provided `name` parameter is safely embedded into the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the `name` is treated as a literal value. Additionally, we should validate that the `name` is a string to prevent any potential injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
