### PR TITLE
Fix code scanning alert no. 64: Type confusion through parameter tampering

### DIFF
--- a/index.js
+++ b/index.js
@@ -542,10 +542,10 @@ app.post('/transferir', transferirLimiter, async (req, res) => {
       });
       return;
     }
-    if (comment.length > 100) {
-      console.log('Comment too long');
+    if (typeof comment !== 'string' || comment.length > 100) {
+      console.log('Invalid comment');
       res.status(400).json({
-        message: 'Comentario muy largo'
+        message: 'Comentario inválido o muy largo'
       });
       return;
     }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/64](https://github.com/ElProConLag/dw_2023/security/code-scanning/64)

To fix the problem, we need to ensure that the `comment` parameter is a string before performing any operations on it. This can be done by adding a type check for `comment` and returning an error if it is not a string. This change should be made in the relevant section of the code where `comment` is used.

1. Add a type check for `comment` to ensure it is a string.
2. If `comment` is not a string, return a 400 Bad Request response with an appropriate error message.
3. This change should be made in the section of the code where `comment` is first used, specifically before the length check on line 545.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
