### PR TITLE
Fix code scanning alert no. 47: Database query built from user-controlled sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ app.post('/ingresar', async (req, res) => {
     return false;
   }
   const collection = client.db("apibank").collection("usuarios");
-  const userExists = await collection.findOne({ email: email });
+  const userExists = await collection.findOne({ email: { $eq: email } });
   console.log('User exists:', userExists);
   if(!userExists) {
     console.log('User does not exist');


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/dw_2023/security/code-scanning/47](https://github.com/ElProConLag/dw_2023/security/code-scanning/47)

To fix the problem, we need to ensure that the user input is sanitized before being used in the MongoDB query. One way to do this is by using the `$eq` operator to ensure that the user input is treated as a literal value. This prevents any potential NoSQL injection attacks.

We will modify the query on line 121 to use the `$eq` operator for the `email` field. This change will ensure that the `email` parameter is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
